### PR TITLE
Fixes tr/td typos in chart documentation

### DIFF
--- a/src/charts/area.md
+++ b/src/charts/area.md
@@ -225,7 +225,7 @@ You can add a [heading](../components/heading/) to your chart using the `<captio
 
 ## Multiple Datasets
 
-You can use a [single dataset](../components/data/) (one `<td>` tag in each `<td>`).
+You can use a [single dataset](../components/data/) (one `<td>` tag in each `<tr>`).
 
 ```html{2}
 <tr>
@@ -233,7 +233,7 @@ You can use a [single dataset](../components/data/) (one `<td>` tag in each `<td
 </tr>
 ```
 
-Or [multiple datasets](../components/datasets/) (many `<td>` tags in `<td>`).
+Or [multiple datasets](../components/datasets/) (many `<td>` tags in `<tr>`).
 
 ```html{2-4}
 <tr>

--- a/src/charts/bar.md
+++ b/src/charts/bar.md
@@ -163,7 +163,7 @@ You can add a [heading](../components/heading/) to your chart using the `<captio
 
 ## Multiple Datasets
 
-You can use a [single dataset](../components/data/) (one `<td>` tag in each `<td>`).
+You can use a [single dataset](../components/data/) (one `<td>` tag in each `<tr>`).
 
 ```html{2}
 <tr>
@@ -171,7 +171,7 @@ You can use a [single dataset](../components/data/) (one `<td>` tag in each `<td
 </tr>
 ```
 
-Or [multiple datasets](../components/datasets/) (many `<td>` tags in `<td>`).
+Or [multiple datasets](../components/datasets/) (many `<td>` tags in `<tr>`).
 
 ```html{2-4}
 <tr>

--- a/src/charts/column.md
+++ b/src/charts/column.md
@@ -162,7 +162,7 @@ You can add a [heading](../components/heading/) to your chart using the `<captio
 
 ## Multiple Datasets
 
-You can use a [single dataset](../components/data/) (one `<td>` tag in each `<td>`).
+You can use a [single dataset](../components/data/) (one `<td>` tag in each `<tr>`).
 
 ```html{2}
 <tr>
@@ -170,7 +170,7 @@ You can use a [single dataset](../components/data/) (one `<td>` tag in each `<td
 </tr>
 ```
 
-Or [multiple datasets](../components/datasets/) (many `<td>` tags in `<td>`).
+Or [multiple datasets](../components/datasets/) (many `<td>` tags in `<tr>`).
 
 ```html{2-4}
 <tr>

--- a/src/charts/line.md
+++ b/src/charts/line.md
@@ -229,7 +229,7 @@ You can add a [heading](../components/heading/) to your chart using the `<captio
 
 ## Multiple Datasets
 
-You can use a [single dataset](../components/data/) (one `<td>` tag in each `<td>`).
+You can use a [single dataset](../components/data/) (one `<td>` tag in each `<tr>`).
 
 ```html{2}
 <tr>
@@ -237,7 +237,7 @@ You can use a [single dataset](../components/data/) (one `<td>` tag in each `<td
 </tr>
 ```
 
-Or [multiple datasets](../components/datasets/) (many `<td>` tags in `<td>`).
+Or [multiple datasets](../components/datasets/) (many `<td>` tags in `<tr>`).
 
 ```html{2-4}
 <tr>


### PR DESCRIPTION
The following `charts/` documentation pages incorrectly specified that a `<td>` should be placed within another `<td>` for datasets and have been updated:

- area.md
- bar.md
- column.md
- line.md